### PR TITLE
WIP: Add tests for HttpPostContext content-type

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,25 @@ httpPost {
 }
 ```
 
+You may also specify a custom content type in the request's header :
+```kotlin
+httpPost {
+    header { "Content-Type" to "text/html" }
+    body {
+        string("<html><body><h1>Hello world</h1></body></html>")
+    }
+}
+```
+
+
+##### Content type priority
+
+Content type is set according to the following priority levels (higher is prioritized) :
+
+1. Header : ```kotlin ... header { "Content-Type" to "$myContenType" } ... ```  
+2. Custom body type : ```kotlin ... body(myContentType) { ... } ...```
+3. Form or Json in body :  ```kotlin ... body() { json { ... } } ...```
+
 
    
 #### HEAD

--- a/src/main/kotlin/io/github/rybalkinsd/kohttp/dsl/context/HeaderContext.kt
+++ b/src/main/kotlin/io/github/rybalkinsd/kohttp/dsl/context/HeaderContext.kt
@@ -18,4 +18,8 @@ class HeaderContext {
     }
 
     internal fun forEach(action: (k: String, v: Any) -> Unit) = map.forEach(action)
+
+    fun getContentType(): String? {
+        return map["Content-Type"] as String?
+    }
 }

--- a/src/main/kotlin/io/github/rybalkinsd/kohttp/dsl/context/HttpContext.kt
+++ b/src/main/kotlin/io/github/rybalkinsd/kohttp/dsl/context/HttpContext.kt
@@ -26,7 +26,7 @@ sealed class HttpContext(private val method: Method = GET) : IHttpContext {
     var path: String? = null
 
     fun param(init: ParamContext.() -> Unit) {
-         paramContext.init()
+        paramContext.init()
     }
 
     fun header(init: HeaderContext.() -> Unit) {
@@ -66,12 +66,16 @@ sealed class HttpContext(private val method: Method = GET) : IHttpContext {
 
     open fun makeBody(): RequestBody = throw UnsupportedOperationException("Request body is not supported for [$method] Method.")
 
+    fun getHeaderContentType(): String? {
+        return headerContext.getContentType()
+    }
+
 }
 
-open class HttpPostContext(method: Method = POST): HttpContext(method) {
+open class HttpPostContext(method: Method = POST) : HttpContext(method) {
     private var body: RequestBody = RequestBody.create(null, byteArrayOf())
 
-    fun body(contentType: String? = null, init: BodyContext.() -> RequestBody) {
+    fun body(contentType: String? = getHeaderContentType(), init: BodyContext.() -> RequestBody) {
         body = BodyContext(contentType).init()
     }
 
@@ -81,9 +85,9 @@ open class HttpPostContext(method: Method = POST): HttpContext(method) {
 
 class HttpGetContext : HttpContext()
 class HttpHeadContext : HttpContext(method = HEAD)
-class HttpPutContext: HttpPostContext(method = PUT)
-class HttpPatchContext: HttpPostContext(method = PATCH)
-class HttpDeleteContext: HttpPostContext(method = DELETE)
+class HttpPutContext : HttpPostContext(method = PUT)
+class HttpPatchContext : HttpPostContext(method = PATCH)
+class HttpDeleteContext : HttpPostContext(method = DELETE)
 
 enum class Method {
     GET, POST, PUT, DELETE, PATCH, HEAD

--- a/src/test/kotlin/io/github/rybalkinsd/kohttp/dsl/context/HttpPostContextTest.kt
+++ b/src/test/kotlin/io/github/rybalkinsd/kohttp/dsl/context/HttpPostContextTest.kt
@@ -1,0 +1,52 @@
+package io.github.rybalkinsd.kohttp.dsl.context
+
+import org.junit.Test
+import kotlin.test.assertEquals
+
+/**
+ * @author mlevesquedion
+ */
+class HttpPostContextTest {
+    @Test
+    fun `when body is form content type should be x-www-form-urlencoded`() {
+        val expectedContentType = "application/x-www-form-urlencoded; charset=utf-8"
+        val context = HttpPostContext()
+        context.body { form { } }
+        assertEquals(context.makeBody().contentType().toString(), expectedContentType)
+    }
+
+    @Test
+    fun `when body is json content type should be json`() {
+        val expectedContentType = "application/json; charset=utf-8"
+        val context = HttpPostContext()
+        context.body { json { } }
+        assertEquals(context.makeBody().contentType().toString(), expectedContentType)
+    }
+
+    @Test
+    fun `should accept custom content type`() {
+        val contentType = "application/xml; charset=utf-8"
+        val context = HttpPostContext()
+        context.body(contentType) { string("content")  }
+        assertEquals(context.makeBody().contentType().toString(), contentType)
+    }
+
+    @Test
+    fun `when custom type is provided and body is form, content type should be form`() {
+        val contentType = "application/xml; charset=utf-8"
+        val expectedContentType = "application/x-www-form-urlencoded; charset=utf-8"
+        val context = HttpPostContext()
+        context.body(contentType) { form {}  }
+        assertEquals(context.makeBody().contentType().toString(), expectedContentType)
+    }
+
+    @Test
+    fun `when custom type is provided and body is json, content type should be json`() {
+        val contentType = "application/xml; charset=utf-8"
+        val expectedContentType = "application/json; charset=utf-8"
+        val context = HttpPostContext()
+        context.body(contentType) { json {}  }
+        assertEquals(context.makeBody().contentType().toString(), expectedContentType)
+    }
+}
+

--- a/src/test/kotlin/io/github/rybalkinsd/kohttp/dsl/context/HttpPostContextTest.kt
+++ b/src/test/kotlin/io/github/rybalkinsd/kohttp/dsl/context/HttpPostContextTest.kt
@@ -24,10 +24,18 @@ class HttpPostContextTest {
     }
 
     @Test
-    fun `should accept custom content type`() {
+    fun `should set content type from header`() {
         val contentType = "application/xml; charset=utf-8"
         val context = HttpPostContext()
-        context.body(contentType) { string("content")  }
+        context.header { "Content-Type" to contentType }
+        assertEquals(context.makeBody().contentType().toString(), contentType)
+    }
+
+    @Test
+    fun `should set custom content type from body`() {
+        val contentType = "application/xml; charset=utf-8"
+        val context = HttpPostContext()
+        context.body(contentType) { string("content") }
         assertEquals(context.makeBody().contentType().toString(), contentType)
     }
 
@@ -36,7 +44,7 @@ class HttpPostContextTest {
         val contentType = "application/xml; charset=utf-8"
         val expectedContentType = "application/x-www-form-urlencoded; charset=utf-8"
         val context = HttpPostContext()
-        context.body(contentType) { form {}  }
+        context.body(contentType) { form {} }
         assertEquals(context.makeBody().contentType().toString(), expectedContentType)
     }
 
@@ -45,8 +53,9 @@ class HttpPostContextTest {
         val contentType = "application/xml; charset=utf-8"
         val expectedContentType = "application/json; charset=utf-8"
         val context = HttpPostContext()
-        context.body(contentType) { json {}  }
+        context.body(contentType) { json {} }
         assertEquals(context.makeBody().contentType().toString(), expectedContentType)
     }
+
 }
 

--- a/src/test/kotlin/io/github/rybalkinsd/kohttp/dsl/context/HttpPostContextTest.kt
+++ b/src/test/kotlin/io/github/rybalkinsd/kohttp/dsl/context/HttpPostContextTest.kt
@@ -28,6 +28,7 @@ class HttpPostContextTest {
         val contentType = "application/xml; charset=utf-8"
         val context = HttpPostContext()
         context.header { "Content-Type" to contentType }
+        context.body { string("content") }
         assertEquals(contentType, context.makeBody().contentType().toString())
     }
 
@@ -56,6 +57,5 @@ class HttpPostContextTest {
         context.body(contentType) { json {} }
         assertEquals(expectedContentType, context.makeBody().contentType().toString())
     }
-
 }
 

--- a/src/test/kotlin/io/github/rybalkinsd/kohttp/dsl/context/HttpPostContextTest.kt
+++ b/src/test/kotlin/io/github/rybalkinsd/kohttp/dsl/context/HttpPostContextTest.kt
@@ -12,7 +12,7 @@ class HttpPostContextTest {
         val expectedContentType = "application/x-www-form-urlencoded; charset=utf-8"
         val context = HttpPostContext()
         context.body { form { } }
-        assertEquals(context.makeBody().contentType().toString(), expectedContentType)
+        assertEquals(expectedContentType, context.makeBody().contentType().toString())
     }
 
     @Test
@@ -20,7 +20,7 @@ class HttpPostContextTest {
         val expectedContentType = "application/json; charset=utf-8"
         val context = HttpPostContext()
         context.body { json { } }
-        assertEquals(context.makeBody().contentType().toString(), expectedContentType)
+        assertEquals(expectedContentType, context.makeBody().contentType().toString())
     }
 
     @Test
@@ -28,7 +28,7 @@ class HttpPostContextTest {
         val contentType = "application/xml; charset=utf-8"
         val context = HttpPostContext()
         context.header { "Content-Type" to contentType }
-        assertEquals(context.makeBody().contentType().toString(), contentType)
+        assertEquals(contentType, context.makeBody().contentType().toString())
     }
 
     @Test
@@ -36,16 +36,16 @@ class HttpPostContextTest {
         val contentType = "application/xml; charset=utf-8"
         val context = HttpPostContext()
         context.body(contentType) { string("content") }
-        assertEquals(context.makeBody().contentType().toString(), contentType)
+        assertEquals(contentType, context.makeBody().contentType().toString())
     }
 
     @Test
-    fun `when custom type is provided and body is form, content type should be form`() {
-        val contentType = "application/xml; charset=utf-8"
-        val expectedContentType = "application/x-www-form-urlencoded; charset=utf-8"
+    fun `should override custom content type with type inside body`() {
+        val customContentType = "application/xml; charset=utf-8"
+        val bodyContentType = "application/x-www-form-urlencoded; charset=utf-8"
         val context = HttpPostContext()
-        context.body(contentType) { form {} }
-        assertEquals(context.makeBody().contentType().toString(), expectedContentType)
+        context.body(customContentType) { form {} }
+        assertEquals(bodyContentType, context.makeBody().contentType().toString())
     }
 
     @Test
@@ -54,7 +54,7 @@ class HttpPostContextTest {
         val expectedContentType = "application/json; charset=utf-8"
         val context = HttpPostContext()
         context.body(contentType) { json {} }
-        assertEquals(context.makeBody().contentType().toString(), expectedContentType)
+        assertEquals(expectedContentType, context.makeBody().contentType().toString())
     }
 
 }

--- a/src/test/kotlin/io/github/rybalkinsd/kohttp/dsl/context/HttpPostContextTest.kt
+++ b/src/test/kotlin/io/github/rybalkinsd/kohttp/dsl/context/HttpPostContextTest.kt
@@ -49,13 +49,5 @@ class HttpPostContextTest {
         assertEquals(bodyContentType, context.makeBody().contentType().toString())
     }
 
-    @Test
-    fun `when custom type is provided and body is json, content type should be json`() {
-        val contentType = "application/xml; charset=utf-8"
-        val expectedContentType = "application/json; charset=utf-8"
-        val context = HttpPostContext()
-        context.body(contentType) { json {} }
-        assertEquals(expectedContentType, context.makeBody().contentType().toString())
-    }
 }
 

--- a/src/test/kotlin/io/github/rybalkinsd/kohttp/dsl/context/HttpPostContextTest.kt
+++ b/src/test/kotlin/io/github/rybalkinsd/kohttp/dsl/context/HttpPostContextTest.kt
@@ -41,6 +41,16 @@ class HttpPostContextTest {
     }
 
     @Test
+    fun `should override header content type with custom content type`() {
+        val headerContentType = "text/css; charset=utf-8"
+        val customContentType = "text/html; charset=utf-8"
+        val context = HttpPostContext()
+        context.header { "Content-Type" to headerContentType }
+        context.body(customContentType) { string("content") }
+        assertEquals(customContentType, context.makeBody().contentType().toString())
+    }
+
+    @Test
     fun `should override custom content type with type inside body`() {
         val customContentType = "application/xml; charset=utf-8"
         val bodyContentType = "application/x-www-form-urlencoded; charset=utf-8"
@@ -48,6 +58,5 @@ class HttpPostContextTest {
         context.body(customContentType) { form {} }
         assertEquals(bodyContentType, context.makeBody().contentType().toString())
     }
-
 }
 


### PR DESCRIPTION
I've added a couple tests which I think cover most of the functionality. I couldn't get the first way (header) to work.

I don't believe this is ready to merge, hence the "WIP" in the title. Mostly looking to see whether I'm going in the right direction or not.

Cheers!