### PR TITLE
WIP: adds interceptor to sign query params

### DIFF
--- a/src/main/kotlin/io/github/rybalkinsd/kohttp/interceptors/SigningInterceptor.kt
+++ b/src/main/kotlin/io/github/rybalkinsd/kohttp/interceptors/SigningInterceptor.kt
@@ -12,27 +12,27 @@ import okhttp3.Response
  * @param parameterName the name of the parameter with signed key
  * @param signer function with HttpUrl as a receiver to sign the request parameter
  *
- * @see HttpUrl
+ * @see HttpUrl.Builder.addQueryParameter
  *
  * @since 0.8.0
  * @author gokul
  */
 
 class SigningInterceptor(private val parameterName: String, private val signer: HttpUrl.() -> String) : Interceptor {
-    override fun intercept(chain: Interceptor.Chain): Response {
+    override fun intercept(chain: Interceptor.Chain): Response =
 
-        return with(chain.request()) {
-            val signedKey = signer(url())
+            with(chain.request()) {
+                val signedKey = signer(url())
 
-            val requestUrl = with(url().newBuilder()) {
-                addQueryParameter(parameterName, signedKey)
-                build()
+                val requestUrl = with(url().newBuilder()) {
+                    addQueryParameter(parameterName, signedKey)
+                    build()
+                }
+
+                with(newBuilder()) {
+                    url(requestUrl)
+                    chain.proceed(build())
+                }
             }
-
-            with(newBuilder()) {
-                url(requestUrl)
-                chain.proceed(build())
-            }
-        }
-    }
 }
+

--- a/src/main/kotlin/io/github/rybalkinsd/kohttp/interceptors/SigningInterceptor.kt
+++ b/src/main/kotlin/io/github/rybalkinsd/kohttp/interceptors/SigningInterceptor.kt
@@ -5,6 +5,20 @@ import okhttp3.Interceptor
 import okhttp3.Request
 import okhttp3.Response
 
+/**
+ * Request Signing Interceptor
+ *
+ * Enables signing of query parameters.
+ *
+ * @param parameterName the name of the parameter with signed key
+ * @param signer function with HttpUrl as a receiver to sign the request parameter
+ *
+ * @see HttpUrl
+ *
+ * @since 0.8.0
+ * @author gokul
+ */
+
 class SigningInterceptor(private val parameterName: String, private val signer: HttpUrl.() -> String) : Interceptor {
     override fun intercept(chain: Interceptor.Chain): Response {
 

--- a/src/main/kotlin/io/github/rybalkinsd/kohttp/interceptors/SigningInterceptor.kt
+++ b/src/main/kotlin/io/github/rybalkinsd/kohttp/interceptors/SigningInterceptor.kt
@@ -1,0 +1,23 @@
+package io.github.rybalkinsd.kohttp.interceptors
+
+import okhttp3.HttpUrl
+import okhttp3.Interceptor
+import okhttp3.Request
+import okhttp3.Response
+
+class SigningInterceptor(private val parameterName: String, private val signer: HttpUrl.() -> String) : Interceptor {
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val userRequest: Request = chain.request()
+        val requestBuilder = userRequest.newBuilder()
+
+        val url = userRequest.url()
+        val urlBuilder = url.newBuilder()
+
+        val signedKey = signer(url)
+
+        urlBuilder.addQueryParameter(parameterName, signedKey).build()
+        requestBuilder.url(urlBuilder.build())
+
+        return chain.proceed(requestBuilder.build())
+    }
+}

--- a/src/main/kotlin/io/github/rybalkinsd/kohttp/interceptors/SigningInterceptor.kt
+++ b/src/main/kotlin/io/github/rybalkinsd/kohttp/interceptors/SigningInterceptor.kt
@@ -2,7 +2,6 @@ package io.github.rybalkinsd.kohttp.interceptors
 
 import okhttp3.HttpUrl
 import okhttp3.Interceptor
-import okhttp3.Request
 import okhttp3.Response
 
 /**

--- a/src/test/kotlin/io/github/rybalkinsd/kohttp/interceptors/SigningInterceptorTest.kt
+++ b/src/test/kotlin/io/github/rybalkinsd/kohttp/interceptors/SigningInterceptorTest.kt
@@ -1,0 +1,43 @@
+package io.github.rybalkinsd.kohttp.interceptors
+
+import io.github.rybalkinsd.kohttp.client.defaultHttpClient
+import io.github.rybalkinsd.kohttp.client.fork
+import io.github.rybalkinsd.kohttp.dsl.httpGet
+import io.github.rybalkinsd.kohttp.util.asJson
+import org.junit.Test
+import java.security.MessageDigest
+import java.util.*
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class SigningInterceptorTest {
+    @Test
+    fun `signs request with MD5 algorithm`() {
+        val urlEncoder = Base64.getUrlEncoder()
+        val algorithm = MessageDigest.getInstance("md5")
+
+        val client = defaultHttpClient.fork {
+            interceptors = listOf(SigningInterceptor("key") {
+                val query = (query() ?: "").toByteArray()
+                urlEncoder.encodeToString(algorithm.digest(query))
+            })
+        }
+
+        val s = "foo=bar&random=213".toByteArray(Charsets.UTF_8)
+        val expected = urlEncoder.encodeToString(MessageDigest.getInstance("md5").digest(s))
+
+        httpGet(client = client) {
+            host = "postman-echo.com"
+            path = "/get"
+
+            param {
+                "foo" to "bar"
+                "random" to 213
+            }
+        }.use {
+            val parsedResponse = it.body()?.string().asJson()
+            assertTrue { it.code() == 200 }
+            assertEquals(expected, parsedResponse["args"]["key"].asText())
+        }
+    }
+}


### PR DESCRIPTION
Initial implementation for #52.

I considered both the approaches mentioned in the issue. 

### DSL on params
- Simple, straightforward
- It was at the request level
- Limited to just the query params

### Defining an interceptor
- Defined at the client level
- Potential to access other aspects of the Request for signing the request

Different services sign their requests differently eg: [amazon](https://docs.aws.amazon.com/general/latest/gr/sigv4-create-string-to-sign.html) vs [twitter](https://developer.twitter.com/en/docs/basics/authentication/guides/creating-a-signature)

@rybalkinsd But would it be more flexible to let user the user define their own interceptor? Thoughts? 

We can further refactor the implementation based on the design we arrive at.

