### PR TITLE
#113 fix:

### DIFF
--- a/src/main/kotlin/io/github/rybalkinsd/kohttp/util/json.kt
+++ b/src/main/kotlin/io/github/rybalkinsd/kohttp/util/json.kt
@@ -21,23 +21,28 @@ class Json {
     infix fun String.to(obj: List<*>) {
         val v = obj.joinToString(separator = ",", prefix = "[", postfix = "]") {
             when (it) {
-                is Number, is Json -> it.toString()
+                null -> "null"
+                is Number, is Json, is Boolean -> it.toString()
                 else -> """"$it""""
             }
         }
         elements += Pair(this, v)
     }
 
-    infix fun String.to(str: String) {
-        elements += Pair(this, """"$str"""")
+    infix fun String.to(str: String?) {
+        elements += if (str == null) Pair(this, "null") else Pair(this, """"$str"""")
     }
 
-    infix fun String.to(num: Number) {
+    infix fun String.to(num: Number?) {
         elements += Pair(this, num.toString())
     }
 
-    infix fun String.to(json: Json) {
+    infix fun String.to(json: Json?) {
         elements += Pair(this, json.toString())
+    }
+
+    infix fun String.to(bool: Boolean?) {
+        elements += Pair(this, bool.toString())
     }
 
     override fun toString(): String =

--- a/src/test/kotlin/io/github/rybalkinsd/kohttp/util/JsonKtTest.kt
+++ b/src/test/kotlin/io/github/rybalkinsd/kohttp/util/JsonKtTest.kt
@@ -9,11 +9,20 @@ import kotlin.test.assertEquals
 class JsonKtTest {
 
     @Test
-    fun `string to string one field json`() {
+    fun `string one field json`() {
         val json = json {
             "a" to "1"
         }
         assertEquals("""{"a":"1"}""", json)
+    }
+
+    @Test
+    fun `nullable string one field json`() {
+        val nString: String? = null
+        val json = json {
+            "a" to nString
+        }
+        assertEquals("""{"a":null}""", json)
     }
 
     @Test
@@ -26,6 +35,15 @@ class JsonKtTest {
     }
 
     @Test
+    fun `nullable number json`() {
+        val nNumber: Number? = null
+        val json = json {
+            "a" to nNumber
+        }
+        assertEquals("""{"a":null}""", json)
+    }
+
+    @Test
     fun `json with list of Number`() {
         val json = json {
             "a" to listOf(1, 2f, 3L)
@@ -35,12 +53,32 @@ class JsonKtTest {
     }
 
     @Test
+    fun `json with list of nullable Number`() {
+        val nNumber: Number? = null
+        val json = json {
+            "a" to listOf(1, 2f, nNumber, 3L)
+            "b" to 2
+        }
+        assertEquals("""{"a":[1,2.0,null,3],"b":2}""", json)
+    }
+
+
+    @Test
     fun `json with list of String`() {
         val json = json {
             "a" to listOf("x1", "x2", "x3")
             "b" to 2
         }
         assertEquals("""{"a":["x1","x2","x3"],"b":2}""", json)
+    }
+
+    @Test
+    fun `json with list of nullable String`() {
+        val nString: String? = null
+        val json = json {
+            "a" to listOf("x1", nString, "x3")
+        }
+        assertEquals("""{"a":["x1",null,"x3"]}""", json)
     }
 
     @Test
@@ -57,6 +95,16 @@ class JsonKtTest {
     }
 
     @Test
+    fun `json with inner nullable json`() {
+        val nJson: Json? = null
+        val json = json {
+            "a" to nJson
+        }
+        assertEquals("""{"a":null}""", json)
+    }
+
+
+    @Test
     fun `json with inner list of any`() {
         val json = json {
             "a" to json {
@@ -64,6 +112,33 @@ class JsonKtTest {
             }
         }
         assertEquals("""{"a":{"i":["x",42,2.0,"any"]}}""", json)
+    }
+
+    @Test
+    fun `json with inner list of nullable any`() {
+        val json = json {
+            "a" to json {
+                "i" to listOf("x", 42, 2.0, null, "any")
+            }
+        }
+        assertEquals("""{"a":{"i":["x",42,2.0,null,"any"]}}""", json)
+    }
+
+    @Test
+    fun `json with boolean`() {
+        val json = json {
+            "a" to true
+        }
+        assertEquals("""{"a":true}""", json)
+    }
+
+    @Test
+    fun `json with nullable boolean`() {
+        val nBoolean: Boolean? = null
+        val json = json {
+            "a" to nBoolean
+        }
+        assertEquals("""{"a":null}""", json)
     }
 
 }


### PR DESCRIPTION
+ Boolean support for `json { }` builder
+ Number?, String? and inner Json? support