### PR TITLE
Add tests for HttpPostContext content-type

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ Content type is set according to the following priority levels (higher is priori
 
 1. Form or Json in body :  ```kotlin ... body() { json { ... } } ...```
 2. Custom body type : ```kotlin ... body(myContentType) { ... } ...```
+3. Header : ```kotlin ... header { "Content-type" to myContentType } ...```
  
 ##### POST with multipart body
 ```kotlin

--- a/README.md
+++ b/README.md
@@ -178,6 +178,12 @@ httpPost {
 }
 ```
 
+##### Content type priority
+Content type is set according to the following priority levels (higher is prioritized)
+
+1. Form or Json in body :  ```kotlin ... body() { json { ... } } ...```
+2. Custom body type : ```kotlin ... body(myContentType) { ... } ...```
+ 
 ##### POST with multipart body
 ```kotlin
 val response = httpPost {

--- a/src/test/kotlin/io/github/rybalkinsd/kohttp/PostmanEchoResponse.kt
+++ b/src/test/kotlin/io/github/rybalkinsd/kohttp/PostmanEchoResponse.kt
@@ -1,0 +1,18 @@
+package io.github.rybalkinsd.kohttp
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+
+/**
+ * Mapping definition class for response from http://postman-echo.com
+ *
+ * Usage example
+ *  <pre>
+ *  val res = jacksonObjectMapper().readValue(bodyString, PostmanEchoResponse::class.java)
+ *  </pre>
+ *
+ * @author doyaaaaaken
+ */
+@JsonIgnoreProperties(ignoreUnknown=true)
+data class PostmanEchoResponse(
+    val headers: Map<String, String>
+)

--- a/src/test/kotlin/io/github/rybalkinsd/kohttp/dsl/context/HttpPostContextTest.kt
+++ b/src/test/kotlin/io/github/rybalkinsd/kohttp/dsl/context/HttpPostContextTest.kt
@@ -1,5 +1,9 @@
 package io.github.rybalkinsd.kohttp.dsl.context
 
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import io.github.rybalkinsd.kohttp.PostmanEchoResponse
+import io.github.rybalkinsd.kohttp.dsl.httpPost
+import io.github.rybalkinsd.kohttp.ext.url
 import org.junit.Test
 import kotlin.test.assertEquals
 
@@ -42,5 +46,40 @@ class HttpPostContextTest {
         context.body("application/json; charset=utf-8") { form("") }
 
         assertEquals(expected, context.makeBody().contentType().toString())
+    }
+
+    @Test
+    fun `header's content type is used on request when content type is set only on header (not set to body)`() {
+        httpPost {
+            url("https://postman-echo.com/post")
+            header { "Content-Type" to "application/json; charset=utf-8" }
+            body { string("content") }
+        }.use {
+            val res = jacksonObjectMapper().readValue(it.body()?.string(), PostmanEchoResponse::class.java)
+            assertEquals("application/json; charset=utf-8", res.headers["content-type"])
+        }
+    }
+
+    @Test
+    fun `body's content type is used on request when content type is set on header and body`() {
+        httpPost {
+            url("https://postman-echo.com/post")
+            header { "Content-Type" to "application/x-www-form-urlencoded; charset=utf-8" }
+            body("application/json") { string("content") }
+        }.use {
+            val res = jacksonObjectMapper().readValue(it.body()?.string(), PostmanEchoResponse::class.java)
+            assertEquals("application/json; charset=utf-8", res.headers["content-type"])
+        }
+    }
+
+    @Test
+    fun `inside body's content type is used on request when content type is set on body and inside body`() {
+        httpPost {
+            url("https://postman-echo.com/post")
+            body("application/x-www-form-urlencoded") { json("content") }
+        }.use {
+            val res = jacksonObjectMapper().readValue(it.body()?.string(), PostmanEchoResponse::class.java)
+            assertEquals("application/json; charset=utf-8", res.headers["content-type"])
+        }
     }
 }

--- a/src/test/kotlin/io/github/rybalkinsd/kohttp/dsl/context/HttpPostContextTest.kt
+++ b/src/test/kotlin/io/github/rybalkinsd/kohttp/dsl/context/HttpPostContextTest.kt
@@ -1,0 +1,46 @@
+package io.github.rybalkinsd.kohttp.dsl.context
+
+import org.junit.Test
+import kotlin.test.assertEquals
+
+/**
+ * @author doyaaaaaken
+ */
+class HttpPostContextTest {
+
+    @Test
+    fun `application json content type when content type is set on 'body' method`() {
+        val expected = "application/json; charset=utf-8"
+        val context = HttpPostContext()
+        context.body("application/json") { string("content") }
+
+        assertEquals(expected, context.makeBody().contentType().toString())
+    }
+
+    @Test
+    fun `x-www-form-urlencoded content type when body is form`() {
+        val expected = "application/x-www-form-urlencoded; charset=utf-8"
+        val context = HttpPostContext()
+        context.body { form("") }
+
+        assertEquals(expected, context.makeBody().contentType().toString())
+    }
+
+    @Test
+    fun `application json content type when body is json`() {
+        val expected = "application/json; charset=utf-8"
+        val context = HttpPostContext()
+        context.body { json {} }
+
+        assertEquals(expected, context.makeBody().contentType().toString())
+    }
+
+    @Test
+    fun `content type on 'form' method inside body overrides it on 'body' method`() {
+        val expected = "application/x-www-form-urlencoded; charset=utf-8"
+        val context = HttpPostContext()
+        context.body("application/json; charset=utf-8") { form("") }
+
+        assertEquals(expected, context.makeBody().contentType().toString())
+    }
+}


### PR DESCRIPTION
Hello, I try to resolve #62 , but I can't do to the last.
Because, this comment's ( https://github.com/rybalkinsd/kohttp/issues/62#issue-396198795 ) 1st way ( `header { type }` ) seems not to work.

So, at first I try to implement 2nd and 3rd way's test.