### PR TITLE
[WIP] handle Retry-After header

### DIFF
--- a/kohttp/src/test/kotlin/io/github/rybalkinsd/kohttp/interceptors/RetryInterceptorTest.kt
+++ b/kohttp/src/test/kotlin/io/github/rybalkinsd/kohttp/interceptors/RetryInterceptorTest.kt
@@ -137,14 +137,14 @@ class RetryInterceptorTest {
     fun `not need retry if status code is 200`() {
         val request = Request.Builder().url(HttpUrl.Builder().host(localhost).scheme("http").build()).build()
         val response = Response.Builder().code(200).protocol(Protocol.HTTP_1_1).message("").request(request).build()
-        Assert.assertFalse(RetryInterceptor().isRetry(response, 1))
+        Assert.assertNull(RetryInterceptor().calculateRetryAfter(response, 1, 2, 30))
     }
 
     @Test
     fun `need retry if status code in error codes list`() {
         val request = Request.Builder().url(HttpUrl.Builder().host(localhost).scheme("http").build()).build()
         val response = Response.Builder().code(503).protocol(Protocol.HTTP_1_1).message("").request(request).build()
-        Assert.assertTrue(RetryInterceptor().isRetry(response, 1))
+        Assert.assertNotNull(RetryInterceptor().calculateRetryAfter(response, 1, 2, 30))
     }
 
     private fun getCall(client: OkHttpClient) {


### PR DESCRIPTION
Fixes #105 #108

Read `Retry-After` response header, and decide when to retry next.

This is WIP pull request, so below tasks are not started.

* enable to handle date format's `Retry-After` value. (GMT format  https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Retry-After#Directives )
* add test code

Please review whether the direction is correct.