### PR TITLE
[Issue-206] make param v nullable.

### DIFF
--- a/kohttp/src/main/kotlin/io/github/rybalkinsd/kohttp/util/form.kt
+++ b/kohttp/src/main/kotlin/io/github/rybalkinsd/kohttp/util/form.kt
@@ -10,7 +10,7 @@ import okhttp3.FormBody
 class Form {
     private val bodyBuilder = FormBody.Builder()
 
-    infix fun String.to(v: Any) {
+    infix fun String.to(v: Any?) {
         bodyBuilder.add(this, v.toString())
     }
 

--- a/kohttp/src/test/kotlin/io/github/rybalkinsd/kohttp/util/FormTest.kt
+++ b/kohttp/src/test/kotlin/io/github/rybalkinsd/kohttp/util/FormTest.kt
@@ -2,6 +2,7 @@ package io.github.rybalkinsd.kohttp.util
 
 import okhttp3.FormBody
 import org.junit.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 /**
@@ -11,27 +12,35 @@ class FormTest {
 
     @Test
     fun `make form and check toString`() {
+        val nullableParam: String? = "notNull"
         val form = Form().apply {
             "a" to "x"
             "b" to 4
             "c" to 2.1
+            "d" to nullableParam
+            "e" to null
             " " to " "
             addEncoded("+", "+")
         }.makeBody()
+        val namesToValues = form.toMapNamesToValues()
 
-        assertTrue("a" in form)
-        assertTrue("b" in form)
-        assertTrue("c" in form)
+        assertEquals("x", namesToValues["a"])
+        assertEquals("4", namesToValues["b"])
+        assertEquals("2.1", namesToValues["c"])
+        assertEquals("notNull", namesToValues["d"])
+        assertEquals("null", namesToValues["e"])
+        assertEquals("%20", namesToValues["%20"])
+        assertEquals("+", namesToValues["+"])
 
-        assertTrue("%20" in form)
-        assertTrue(" " !in form)
-
-        assertTrue("+" in form)
-        assertTrue("%2B" !in form)
+        assertTrue(!namesToValues.containsKey(" "))
+        assertTrue(!namesToValues.containsKey("%2B"))
 
     }
 
-    private operator fun FormBody.contains(k: String) =
-        (0 until size).asSequence().any { encodedName(it) == k }
+    private fun FormBody.toMapNamesToValues(): Map<String, String> {
+        return (0 until size)
+            .map { encodedName(it) to encodedValue(it) }
+            .toMap()
+    }
 
 }


### PR DESCRIPTION
Reason: When class Form was using in DSL, function 'to' with nullable param refers to 'kotlin.to' and did not append param.